### PR TITLE
Adding SPM support for MobilePaymentsSDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "SquareMobilePaymentsSDK",
+    products: [
+        .library(name: "SquareMobilePaymentsSDK", targets: ["SquareMobilePaymentsSDK"]),
+        .library(name: "MockReaderUI", targets: ["MockReaderUI"]),
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "SquareMobilePaymentsSDK",
+            path: "XCFrameworks/SquareMobilePaymentsSDK_6432c60c8568.zip"
+        ),
+        .binaryTarget(
+            name: "MockReaderUI",
+            path: "XCFrameworks/MockReaderUI_6432c60c8568.zip"
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CocoaPods](https://img.shields.io/cocoapods/v/SquareMobilePaymentsSDK)](https://github.com/CocoaPods/CocoaPods)
+[![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
 
 # Square Mobile Payments SDK
 
@@ -6,6 +7,20 @@ Build remarkable in-person experiences using Square's Mobile Payments SDK produc
 
 
 ## Installation
+
+### Swift Package Manager
+
+To install the `SquareMobilePaymentsSDK` into your Xcode project, follow these steps:
+
+1. Select `File > Add Package Dependencies...`.
+2. Enter the repository URL: `https://github.com/square/mobile-payments-sdk-ios`.
+3. Select the `Exact Version` dependency rule and specify the version as `2.0.0-beta1`.
+4. Ensure the `SquareMobilePaymentsSDK` product is added to your target.
+
+Optionally, you can also add the `MockReaderUI` product to your target to simulate a physical reader when one is not present in a sandbox environment.
+
+> [!WARNING]  
+> Please note that the `MockReaderUI` product should only be used in debug configurations and is not to be included in the release version of your application.
 
 ### Cocoapods
 


### PR DESCRIPTION
### Description of Change
- Added a Package.swift that specifies products for both SquareMobilePaymentsSDK and MockReaderUI
- Updated README to include installation instructions for both product.

### Testing
- Tested by running `swift package describe` to ensure no parsing issues.
- Tested installing both frameworks in a test repository.