### PR TITLE
Add Missing Square Stand Plist Values

### DIFF
--- a/Example/DonutCounter/DonutCounter.xcodeproj/project.pbxproj
+++ b/Example/DonutCounter/DonutCounter.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		D078B4152D1610BA00BEC35C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D09D322C2CE442F9002DB265 /* Payment+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Payment+Extensions.swift"; sourceTree = "<group>"; };
 		D09D322E2CE445C4002DB265 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		D09D32312CE4704E002DB265 /* IdempotencyKeyStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdempotencyKeyStorage.swift; sourceTree = "<group>"; };
@@ -152,6 +153,7 @@
 		FB1E68DF2C1CC5E8004DC0A9 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				D078B4152D1610BA00BEC35C /* Info.plist */,
 				FB1E68E02C1CC5E8004DC0A9 /* Resources */,
 				FB1E68E32C1CC5E8004DC0A9 /* Config.swift */,
 				FB1E68E42C1CC5E8004DC0A9 /* Preview Content */,
@@ -431,6 +433,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ../Shared/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Donut Counter";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Square uses Bluetooth to connect and communicate with Square readers and compatible accessories.\n";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Square uses location to know where transactions take place to reduce risk and minimize payment disputes.\n";
@@ -470,6 +473,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ../Shared/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Donut Counter";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Square uses Bluetooth to connect and communicate with Square readers and compatible accessories.\n";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Square uses location to know where transactions take place to reduce risk and minimize payment disputes.\n";

--- a/Example/Shared/Info.plist
+++ b/Example/Shared/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UISupportedExternalAccessoryProtocols</key>
+	<array>
+		<string>com.squareup.s020</string>
+		<string>com.squareup.s025</string>
+		<string>com.squareup.s089</string>
+		<string>com.squareup.protocol.stand</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
- Adds [required](https://developer.squareup.com/docs/reader-sdk/cookbook/square-stand#update-your-infoplist-file-for-square-stand) square stand values for `UISupportedExternalAccessoryProtocols` key.