### PR TITLE
Fix Found no destinations for the scheme 'DonutCounter' and action build

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -1,0 +1,8 @@
+name: Setup Xcode
+description: Performs Xcode setup common to the workflows.
+runs:
+  using: composite
+  steps:
+    - name: Select Xcode
+      shell: bash
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
+
+    - name: Setup Xcode
+      uses: ./.github/actions/setup-xcode
 
     - name: Build DonutCounter project
       run: |

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -14,7 +14,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+
+      - name: Setup Xcode
+        uses: ./.github/actions/setup-xcode
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The new runner image for macos-latest doesn't include the iOS 18.0 SDK for /Applications/Xcode_16.app. It does, however, include the iOS 18.5 SDK for /Applications/Xcode_16.4.app. The version update of the checkout action is just to stay current.