### PR TITLE
Fix permission row tap targets and Bluetooth denied handling

### DIFF
--- a/Example/DonutCounter/DonutCounter/Screens/Permissions/PermissionRow.swift
+++ b/Example/DonutCounter/DonutCounter/Screens/Permissions/PermissionRow.swift
@@ -39,9 +39,10 @@ struct PermissionsRow: View {
                 .frame(width: 20, height: 20)
                 .foregroundColor(Color.Permissions.iconColor)
                 .padding(.leading, 16)
-                .onTapGesture {
-                    tapAction?()
-                }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            tapAction?()
         }
         .padding(.bottom, 15)
     }

--- a/Example/DonutCounter/DonutCounter/Screens/Permissions/PermissionsViewModel.swift
+++ b/Example/DonutCounter/DonutCounter/Screens/Permissions/PermissionsViewModel.swift
@@ -33,8 +33,16 @@ import SwiftUI
     // MARK: - Request Permissions
     
     func requestBluetooth() {
-        guard CBManager.authorization == .notDetermined else { return }
-        bluetoothManager = CBCentralManager(delegate: self, queue: .main)
+        switch CBManager.authorization {
+        case .notDetermined:
+            bluetoothManager = CBCentralManager(delegate: self, queue: .main)
+        case .denied, .restricted:
+            openAppSettings()
+        case .allowedAlways:
+            print("Bluetooth has already been authorized.")
+        @unknown default:
+            fatalError("Invalid Bluetooth permission status")
+        }
     }
     
     func requestLocation() {


### PR DESCRIPTION
## Summary
- Make the entire permission row tappable instead of just the tiny 20x20 checkbox icon, using `.contentShape(Rectangle())` + `.onTapGesture` on the `HStack`
- Fix `requestBluetooth()` to open Settings when permission is denied/restricted, matching the existing Location and Microphone behavior (previously it silently did nothing)

## Test plan
- [x] Tap anywhere on a permission row (title, description, spacer area) — should trigger the permission request
- [x] Deny Bluetooth permission, then tap the Bluetooth row — should open app Settings
- [x] Verify Location and Microphone denied flows still open Settings as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)