### PR TITLE
MPSDK: Add latest version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CocoaPods](https://img.shields.io/cocoapods/v/SquareMobilePaymentsSDK)](https://github.com/CocoaPods/CocoaPods)
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
+[![Latest version](https://img.shields.io/badge/latest-2.5.0-blue)](https://github.com/square/mobile-payments-sdk-ios/releases)
 
 # Square Mobile Payments SDK
 


### PR DESCRIPTION
Add a shields.io badge showing the latest version (2.5.0) alongside the existing CocoaPods and SPM badges so visitors immediately see the current release.